### PR TITLE
Tester controllerne

### DIFF
--- a/src/main/kotlin/no/nav/arbeidsplassen/stillingshistorikk/api/AdHistoryContoller.kt
+++ b/src/main/kotlin/no/nav/arbeidsplassen/stillingshistorikk/api/AdHistoryContoller.kt
@@ -3,6 +3,7 @@ package no.nav.arbeidsplassen.stillingshistorikk.api
 import com.fasterxml.jackson.databind.ObjectMapper
 import io.javalin.Javalin
 import io.javalin.http.Context
+import io.javalin.http.HttpStatus
 import no.nav.arbeidsplassen.stillingshistorikk.BigQueryService
 import no.nav.arbeidsplassen.stillingshistorikk.sikkerhet.Rolle
 import org.slf4j.LoggerFactory
@@ -21,7 +22,11 @@ class AdHistoryContoller(
 
     private fun hentStillingsHistorikk(ctx: Context) {
         val uuid = ctx.pathParam("uuid")
-        val år = ctx.queryParam("year")!!.toInt()
+        val år = ctx.queryParam("year")?.toInt()
+        if (år == null) {
+            ctx.status(HttpStatus.BAD_REQUEST).contentType("text/plain").result("Mangler parameter 'year'")
+            return
+        }
         LOG.info("Fetching history for ad: $uuid from year: $år")
         ctx.result(objectMapper.writeValueAsString(bigQueryService.queryAdHistory(uuid, år)))
     }

--- a/src/main/kotlin/no/nav/arbeidsplassen/stillingshistorikk/api/AdHistoryContoller.kt
+++ b/src/main/kotlin/no/nav/arbeidsplassen/stillingshistorikk/api/AdHistoryContoller.kt
@@ -25,6 +25,7 @@ class AdHistoryContoller(
         val år = ctx.queryParam("year")?.toInt()
         if (år == null) {
             ctx.status(HttpStatus.BAD_REQUEST).contentType("text/plain").result("Mangler parameter 'year'")
+            LOG.warn("Mangler parameter 'year'")
         } else {
             ctx.result(objectMapper.writeValueAsString(bigQueryService.queryAdHistory(uuid, år)))
             LOG.info("Henter stillingshistorikk for stilling: $uuid og år: $år")

--- a/src/main/kotlin/no/nav/arbeidsplassen/stillingshistorikk/api/AdHistoryContoller.kt
+++ b/src/main/kotlin/no/nav/arbeidsplassen/stillingshistorikk/api/AdHistoryContoller.kt
@@ -25,9 +25,9 @@ class AdHistoryContoller(
         val år = ctx.queryParam("year")?.toInt()
         if (år == null) {
             ctx.status(HttpStatus.BAD_REQUEST).contentType("text/plain").result("Mangler parameter 'year'")
-            return
+        } else {
+            ctx.result(objectMapper.writeValueAsString(bigQueryService.queryAdHistory(uuid, år)))
+            LOG.info("Henter stillingshistorikk for stilling: $uuid og år: $år")
         }
-        LOG.info("Fetching history for ad: $uuid from year: $år")
-        ctx.result(objectMapper.writeValueAsString(bigQueryService.queryAdHistory(uuid, år)))
     }
 }

--- a/src/main/kotlin/no/nav/arbeidsplassen/stillingshistorikk/api/AdministrationTimeController.kt
+++ b/src/main/kotlin/no/nav/arbeidsplassen/stillingshistorikk/api/AdministrationTimeController.kt
@@ -2,6 +2,7 @@ package no.nav.arbeidsplassen.stillingshistorikk.api
 
 import io.javalin.Javalin
 import io.javalin.http.Context
+import io.javalin.http.HttpStatus
 import no.nav.arbeidsplassen.stillingshistorikk.BigQueryService
 import no.nav.arbeidsplassen.stillingshistorikk.sikkerhet.Rolle
 import org.slf4j.LoggerFactory
@@ -20,12 +21,21 @@ class AdministrationTimeController(
     }
 
     private fun hentBehandlingstid(ctx: Context) {
-        val startTidspunkt = if (ctx.queryParam("from") == null) LocalDate.now().withDayOfMonth(1) else
-            LocalDate.parse(ctx.queryParam("from")!!, DateTimeFormatter.ISO_DATE)
-        val sluttTidspunkt = if (ctx.queryParam("to") == null) startTidspunkt.plusMonths(1) else
-            LocalDate.parse(ctx.queryParam("to")!!, DateTimeFormatter.ISO_DATE)
+        val startTidspunkt = try {
+            ctx.queryParam("from")?.let { LocalDate.parse(it, DateTimeFormatter.ISO_DATE) } ?: LocalDate.now().withDayOfMonth(1)
+        } catch (e: Exception) {
+            ctx.status(HttpStatus.BAD_REQUEST).result("Ugyldig format for parameter 'from'")
+            return
+        }
 
-        LOG.info("Getting report from $startTidspunkt to $sluttTidspunkt");
+        val sluttTidspunkt = try {
+            ctx.queryParam("to")?.let { LocalDate.parse(it, DateTimeFormatter.ISO_DATE) } ?: startTidspunkt.plusMonths(1)
+        } catch (e: Exception) {
+            ctx.status(HttpStatus.BAD_REQUEST).result("Ugyldig format for parameter 'to'")
+            return
+        }
+
+        LOG.info("Getting report from $startTidspunkt to $sluttTidspunkt")
         val behandlingstid = bigQueryService.queryAdministrationTime(startTidspunkt, sluttTidspunkt)
         ctx.contentType("text/csv").result(behandlingstid)
     }

--- a/src/test/kotlin/no/nav/arbeidsplassen/stillingshistorikk/api/AdAvvisningControllerTest.kt
+++ b/src/test/kotlin/no/nav/arbeidsplassen/stillingshistorikk/api/AdAvvisningControllerTest.kt
@@ -1,0 +1,25 @@
+package no.nav.arbeidsplassen.stillingshistorikk.api
+
+import io.javalin.http.HttpStatus
+import no.nav.arbeidsplassen.stillingshistorikk.app.test.TestRunningApplication
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse.BodyHandlers
+
+@TestInstance(TestInstance.Lifecycle.PER_METHOD)
+class AdAvvisningControllerTest : TestRunningApplication() {
+
+    @Test
+    fun `Skal hente avviste stillinger`() {
+        val request = HttpRequest.newBuilder()
+            .uri(URI("$lokalBaseUrl/api/v1/ads/avvisning"))
+            .GET()
+            .build()
+        val response = HttpClient.newBuilder().build().send(request, BodyHandlers.ofString())
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.code)
+    }
+}

--- a/src/test/kotlin/no/nav/arbeidsplassen/stillingshistorikk/api/AdHistoryControllerTest.kt
+++ b/src/test/kotlin/no/nav/arbeidsplassen/stillingshistorikk/api/AdHistoryControllerTest.kt
@@ -24,7 +24,7 @@ class AdHistoryControllerTest : TestRunningApplication() {
     }
 
     @Test
-    fun `Skal hente stillingshistorikk uten år og returnere 400`() {
+    fun `Skal feile ved henting av stillingshistorikk ved manglende parameter 'year' og returnere Bad Request`() {
         val request = HttpRequest.newBuilder()
             .uri(URI("$lokalBaseUrl/api/v1/ads/history/uuid"))
             .GET()

--- a/src/test/kotlin/no/nav/arbeidsplassen/stillingshistorikk/api/AdHistoryControllerTest.kt
+++ b/src/test/kotlin/no/nav/arbeidsplassen/stillingshistorikk/api/AdHistoryControllerTest.kt
@@ -1,0 +1,35 @@
+package no.nav.arbeidsplassen.stillingshistorikk.api
+
+import io.javalin.http.HttpStatus
+import no.nav.arbeidsplassen.stillingshistorikk.app.test.TestRunningApplication
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse.BodyHandlers
+
+@TestInstance(TestInstance.Lifecycle.PER_METHOD)
+class AdHistoryControllerTest : TestRunningApplication() {
+
+    @Test
+    fun `Skal hente stillingshistorikk`() {
+        val request = HttpRequest.newBuilder()
+            .uri(URI("$lokalBaseUrl/api/v1/ads/history/uuid?year=2024"))
+            .GET()
+            .build()
+        val response = HttpClient.newBuilder().build().send(request, BodyHandlers.ofString())
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.code)
+    }
+
+    @Test
+    fun `Skal hente stillingshistorikk uten år og returnere 400`() {
+        val request = HttpRequest.newBuilder()
+            .uri(URI("$lokalBaseUrl/api/v1/ads/history/uuid"))
+            .GET()
+            .build()
+        val response = HttpClient.newBuilder().build().send(request, BodyHandlers.ofString())
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.code)
+    }
+}

--- a/src/test/kotlin/no/nav/arbeidsplassen/stillingshistorikk/api/AdministrationTimeControllerTest.kt
+++ b/src/test/kotlin/no/nav/arbeidsplassen/stillingshistorikk/api/AdministrationTimeControllerTest.kt
@@ -1,0 +1,25 @@
+package no.nav.arbeidsplassen.stillingshistorikk.api
+
+import io.javalin.http.HttpStatus
+import no.nav.arbeidsplassen.stillingshistorikk.app.test.TestRunningApplication
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse.BodyHandlers
+
+@TestInstance(TestInstance.Lifecycle.PER_METHOD)
+class AdministrationTimeControllerTest : TestRunningApplication() {
+
+    @Test
+    fun `Skal hente behandlingstid`() {
+        val request = HttpRequest.newBuilder()
+            .uri(URI("$lokalBaseUrl/api/v1/admin/report/behandlingstid.csv"))
+            .GET()
+            .build()
+        val response = HttpClient.newBuilder().build().send(request, BodyHandlers.ofString())
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.code)
+    }
+}

--- a/src/test/kotlin/no/nav/arbeidsplassen/stillingshistorikk/api/AdministrationTimeControllerTest.kt
+++ b/src/test/kotlin/no/nav/arbeidsplassen/stillingshistorikk/api/AdministrationTimeControllerTest.kt
@@ -22,4 +22,24 @@ class AdministrationTimeControllerTest : TestRunningApplication() {
         val response = HttpClient.newBuilder().build().send(request, BodyHandlers.ofString())
         assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.code)
     }
+
+    @Test
+    fun `Skal returnere Bad Request ved ugyldig 'from' parameter`() {
+        val request = HttpRequest.newBuilder()
+            .uri(URI("$lokalBaseUrl/api/v1/admin/report/behandlingstid.csv?from=ugyldig-dato"))
+            .GET()
+            .build()
+        val response = HttpClient.newBuilder().build().send(request, BodyHandlers.ofString())
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.code)
+    }
+
+    @Test
+    fun `Skal returnere Bad Request ved ugyldig 'to' parameter`() {
+        val request = HttpRequest.newBuilder()
+            .uri(URI("$lokalBaseUrl/api/v1/admin/report/behandlingstid.csv?to=ugyldig-dato"))
+            .GET()
+            .build()
+        val response = HttpClient.newBuilder().build().send(request, BodyHandlers.ofString())
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.code)
+    }
 }


### PR DESCRIPTION
Returnerer 400 når `year` mangler i `/api/v1/ads/history/{uuid}` og lager tester til controllerne